### PR TITLE
refactor: コンポーネント分割

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,9 +5,13 @@ import {
   VIEWPORT_WIDTH, VIEWPORT_HEIGHT, WORLD_WIDTH
 } from './constants';
 import { createInitialState, updateState } from './engine/engine';
-import Player from './components/Player';
 import MapEditor from './components/MapEditor';
-import Spike from './components/Spike';
+import Player from './components/entities/Player';
+import Platform from './components/entities/Platform';
+import Coin from './components/entities/Coin';
+import Enemy from './components/entities/Enemy';
+import Spike from './components/entities/Spike';
+import Goal from './components/entities/Goal';
 import { getAvailableMaps } from './engine/tileMap/tileMapLoader';
 import { createPauseHandler } from './input/pause';
 import { createTitleHandler } from './input/title';
@@ -178,37 +182,18 @@ const App: React.FC = () => {
           style={{ transform: `translateX(-${gameState.viewportX}px)` }}
         >
           {/* Platforms */}
-          {gameState.platforms.map(p => (
-            <div 
-              key={p.id}
-              className="absolute bg-orange-800 border-t-4 border-orange-600"
-              style={{ left: p.pos.x, top: p.pos.y, width: p.size.x, height: p.size.y }}
-            />
+          {gameState.platforms.map(platform => (
+            <Platform key={platform.id} platform={platform} />
           ))}
 
           {/* Coins */}
-          {gameState.coins.map(c => !c.isCollected && (
-            <div 
-              key={c.id}
-              className="absolute rounded-full bg-yellow-400 border-2 border-yellow-600 flex items-center justify-center"
-              style={{ left: c.pos.x, top: c.pos.y, width: c.size.x, height: c.size.y }}
-            >
-              <div className="text-[10px] font-bold text-yellow-800">$</div>
-            </div>
+          {gameState.coins.map(coin => (
+            <Coin key={coin.id} coin={coin} />
           ))}
 
           {/* Enemies */}
-          {gameState.enemies.map(e => !e.isDead && (
-            <div 
-              key={e.id}
-              className="absolute bg-red-600 rounded-lg border-2 border-red-800"
-              style={{ left: e.pos.x, top: e.pos.y, width: e.size.x, height: e.size.y }}
-            >
-              <div className="flex justify-around mt-1">
-                <div className="w-2 h-2 bg-white rounded-full" />
-                <div className="w-2 h-2 bg-white rounded-full" />
-              </div>
-            </div>
+          {gameState.enemies.map(enemy => (
+            <Enemy key={enemy.id} enemy={enemy} />
           ))}
 
           {/* Spikes */}
@@ -218,12 +203,7 @@ const App: React.FC = () => {
 
           {/* Goal */}
           {gameState.star && (
-            <div 
-              className="absolute text-5xl"
-              style={{ left: gameState.star.pos.x, top: gameState.star.pos.y }}
-            >
-              ⭐
-            </div>
+            <Goal star={gameState.star} />
           )}
 
           {/* Player Component */}

--- a/src/components/entities/Coin.tsx
+++ b/src/components/entities/Coin.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Entity } from '../../types/types';
+
+interface CoinProps {
+  coin: Entity;
+}
+
+const Coin: React.FC<CoinProps> = ({ coin }) => {
+  if (coin.isCollected) {
+    return null;
+  }
+
+  return (
+    <div 
+      className="absolute rounded-full bg-yellow-400 border-2 border-yellow-600 flex items-center justify-center"
+      style={{ left: coin.pos.x, top: coin.pos.y, width: coin.size.x, height: coin.size.y }}
+    >
+      <div className="text-[10px] font-bold text-yellow-800">$</div>
+    </div>
+  );
+};
+
+export default Coin;

--- a/src/components/entities/Enemy.tsx
+++ b/src/components/entities/Enemy.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Entity } from '../../types/types';
+
+interface EnemyProps {
+  enemy: Entity;
+}
+
+const Enemy: React.FC<EnemyProps> = ({ enemy }) => {
+  if (enemy.isDead) {
+    return null;
+  }
+
+  return (
+    <div 
+      className="absolute bg-red-600 rounded-lg border-2 border-red-800"
+      style={{ left: enemy.pos.x, top: enemy.pos.y, width: enemy.size.x, height: enemy.size.y }}
+    >
+      <div className="flex justify-around mt-1">
+        <div className="w-2 h-2 bg-white rounded-full" />
+        <div className="w-2 h-2 bg-white rounded-full" />
+      </div>
+    </div>
+  );
+};
+
+export default Enemy;

--- a/src/components/entities/Goal.tsx
+++ b/src/components/entities/Goal.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Entity } from '../../types/types';
+
+interface GoalProps {
+  star: Entity;
+}
+
+const Goal: React.FC<GoalProps> = ({ star }) => {
+  return (
+    <div 
+      className="absolute text-5xl"
+      style={{ left: star.pos.x, top: star.pos.y }}
+    >
+      ⭐
+    </div>
+  );
+};
+
+export default Goal;

--- a/src/components/entities/Platform.tsx
+++ b/src/components/entities/Platform.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Entity } from '../../types/types';
+
+interface PlatformProps {
+  platform: Entity;
+}
+
+const Platform: React.FC<PlatformProps> = ({ platform }) => {
+  return (
+    <div 
+      className="absolute bg-orange-800"
+      style={{ left: platform.pos.x, top: platform.pos.y, width: platform.size.x, height: platform.size.y }}
+    />
+  );
+};
+
+export default Platform;

--- a/src/components/entities/Player.tsx
+++ b/src/components/entities/Player.tsx
@@ -1,7 +1,6 @@
-
 import React from 'react';
-import { Entity } from '../types';
-import { ASSET_PATHS } from '../constants';
+import { Entity } from '../../types';
+import { ASSET_PATHS } from '../../constants';
 
 interface PlayerProps {
   player: Entity & { isHurt?: boolean };

--- a/src/components/entities/Spike.tsx
+++ b/src/components/entities/Spike.tsx
@@ -1,7 +1,6 @@
-
 import React from 'react';
-import { Entity } from '../types/types';
-import '../styles/spike.css';
+import { Entity } from '../../types/types';
+import '../../styles/spike.css';
 
 interface SpikeProps {
   spike: Entity;


### PR DESCRIPTION
コンポーネントが今後増えるので今のうちに分割

タイルマップでの扱う番号とかも修正したい（敵や地面の種類が増えると連番方式だと微妙？）